### PR TITLE
Enabled admin edit status

### DIFF
--- a/UI/js/all-flags.js
+++ b/UI/js/all-flags.js
@@ -6,6 +6,31 @@ const modal = document.querySelector('.modal');
 const closeButton = document.querySelector('.close-button');
 
 // eslint-disable-next-line no-unused-vars
+function editStatus(id, status) {
+  console.log(`${id} ${status}`);
+  const url = `https://andelaireporterapp.herokuapp.com/api/v2/red-flags/${id}/status`;
+  fetch(url, {
+    method: 'PATCH',
+    mode: 'cors',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      status,
+    }),
+  })
+    .then(response => response.json())
+    .then((data) => {
+      if (data.status === 401) {
+        window.location.replace('./signin.html');
+      }
+      if (data.status !== 201) {
+        info.parentElement.style.display = 'block';
+        info.textContent = `${data.error}`;
+      }
+    });
+}
+
+
+// eslint-disable-next-line no-unused-vars
 function getIncidents(incidentType) {
   const url = 'https://andelaireporterapp.herokuapp.com/api/v2/'.concat(incidentType);
   const tableBody = document.querySelector('#incidents-table > tbody');
@@ -22,30 +47,33 @@ function getIncidents(incidentType) {
       }
       if (data.status === 200) {
         data.data.forEach((flag) => {
-        // })
-        // for(const flag of data.data) {
-          const newRow = document.createElement('tr');
-          const flagId = document.createElement('td');
-          flagId.textContent = flag.incident_id;
-          const title = document.createElement('td');
-          title.innerHTML = `<a href="javascript:void(0);" onclick="getIncident(${flag.incident_id}); toggleModal();">${flag.title}</a>`;
-          const flagType = document.createElement('td');
-          flagType.textContent = flag.type;
-          const createdOn = document.createElement('td');
-          createdOn.textContent = flag.created_on;
-          const accept = document.createElement('td');
-          accept.innerHTML = '<a href=""><i class="fa fa-check-square-o" aria-hidden="true"></i></a>';
-          const reject = document.createElement('td');
-          reject.innerHTML = '<a href=""><i class="fa fa-ban" aria-hidden="true"></i></a>';
+          if (flag.status === 'under investigation') {
+            const newRow = document.createElement('tr');
+            const flagId = document.createElement('td');
+            flagId.textContent = flag.incident_id;
+            const title = document.createElement('td');
+            title.innerHTML = `<a href="javascript:void(0);" onclick="getIncident(${flag.incident_id}); toggleModal();">${flag.title}</a>`;
+            const flagType = document.createElement('td');
+            flagType.textContent = flag.type;
+            const createdOn = document.createElement('td');
+            createdOn.textContent = flag.created_on;
+            const accept = document.createElement('td');
+            accept.innerHTML = `<a href="javascript:void(0);" onclick="editStatus(${flag.incident_id}, 'resolved');"><i class="fa fa-check-square-o" aria-hidden="true"></i></a>`;
+            const reject = document.createElement('td');
+            reject.innerHTML = `<a href="javascript:void(0);" onclick="editStatus(${flag.incident_id}, 'rejected');"><i class="fa fa-ban" aria-hidden="true"></i></a>`;
 
-          newRow.appendChild(flagId);
-          newRow.appendChild(title);
-          newRow.appendChild(flagType);
-          newRow.appendChild(createdOn);
-          newRow.appendChild(accept);
-          newRow.appendChild(reject);
+            newRow.appendChild(flagId);
+            newRow.appendChild(title);
+            newRow.appendChild(flagType);
+            newRow.appendChild(createdOn);
+            newRow.appendChild(accept);
+            newRow.appendChild(reject);
 
-          tableBody.appendChild(newRow);
+            tableBody.appendChild(newRow);
+          } else {
+            info.parentElement.style.display = 'block';
+            info.textContent = 'No new incidents have been created';
+          }
         });
       } else {
         info.parentElement.style.display = 'block';

--- a/UI/js/edit-incident.js
+++ b/UI/js/edit-incident.js
@@ -41,6 +41,13 @@ function editLocation(id, coord) {
         info.parentElement.style.display = 'block';
         info.textContent = `${data.error}`;
       }
+
+      if (data.status === 201) {
+        info.parentElement.style.display = 'block';
+        info.textContent = `${data.message}`;
+      }
+      info.parentElement.style.display = 'block';
+      info.textContent = `${data.message}`;
     });
 }
 

--- a/UI/js/get_incident.js
+++ b/UI/js/get_incident.js
@@ -19,11 +19,13 @@ function getIncident(incidentId) {
         const flagId = document.getElementById('t-head');
         flagId.textContent = `Incident #${data.data[0].incident_id}`;
         const editIncident = document.getElementById('edit');
-        editIncident.innerHTML = `<a href="edit.html?
+        if (editIncident) {
+          editIncident.innerHTML = `<a href="edit.html?
           &id=${data.data[0].incident_id}
           &location=${data.data[0].location}
           &comment=${data.data[0].comment}
           &title=${data.data[0].title}">Edit this incident</a>`;
+        }
         const title = document.getElementById('title');
         title.textContent = data.data[0].title;
         const flagType = document.getElementById('type');


### PR DESCRIPTION
This PR will enable an admin (and only an admin) to edit the status of an incident. This has no much effect on the user so as a normal user all you can do is create an incident and wait for it to be either approved or rejected. You can check which of your incidents have been rejected, approved or still under investigation in your profile.

To test this feature, please login(or sign up and then log in) in case you have no account yet:
-Register for an account at https://v1b3m.github.io/project_ireporter_api/UI/signup.html
-Then log in at https://v1b3m.github.io/project_ireporter_api/UI/signin.html

On logging in you, need to create an incident which will then be displayed on the home page, click on the title of the incident to get the incident details displayed to you in a pop up table, in the table header you'll see a link that says, `Edit this incident`, click on that and head on to change the data to the new updated data. This will redirect you to the incident page on completion and you can now check your incident to confirm that the data has been updated successfully.

@nicholus @Rhytah @JamesMudidi @sanya-kenneth @frankopkusianwar @AtamaZack @ManuelDominic @KabohaJeanMark @nadralia @reifred @llwasampijja @richien @Genza999 @3Nakajugo @e-ian @Manorlds-Eaglespark @PatrickMugayaJoel @bisonlou @kalsmic @mwinel

Apologies; All those who created accounts before will have to recreate accounts since I've torn down the tables. Sorry for the incovenience.